### PR TITLE
Add RPI4 to the list of supported boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ by the boards they support:
 * `rpi2` Raspberry Pi 2 Model B
 * `rpi3` - Raspberry Pi 3 Model B and Model B+
 * `rpi3a` - Raspberry Pi 3 Model A+
+* `rpi4` - Raspberry Pi 4 Model B
 
 Once that's done, you're ready to burn the firmware to the MicroSD card.
 


### PR DESCRIPTION
If I'm not mistaken, the 4 is now supported? I can see the firmware in the builds - sorry if I've made a mistake. 