### PR TITLE
Bump Elixir requirement to 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule CircuitsQuickstart.MixProject do
     [
       app: @app,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       archives: [nerves_bootstrap: "~> 1.9"],
       start_permanent: Mix.env() == :prod,
       build_embedded: true,


### PR DESCRIPTION
This works around issue #22. In theory, it should be possible to work
with Elixir 1.10, but I don't think anyone maintain Elixir Circuits uses
it any more.