### PR TITLE
Use board-specific network configurations

### DIFF
--- a/config/bbb.exs
+++ b/config/bbb.exs
@@ -1,0 +1,11 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/giant_board.exs
+++ b/config/giant_board.exs
@@ -1,0 +1,10 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  ]

--- a/config/npi_imx6ull.exs
+++ b/config/npi_imx6ull.exs
@@ -1,0 +1,11 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"eth1", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  ]

--- a/config/osd32mp1.exs
+++ b/config/osd32mp1.exs
@@ -1,0 +1,10 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  ]

--- a/config/rpi.exs
+++ b/config/rpi.exs
@@ -1,0 +1,10 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/rpi0.exs
+++ b/config/rpi0.exs
@@ -1,0 +1,10 @@
+use Mix.Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/rpi2.exs
+++ b/config/rpi2.exs
@@ -1,0 +1,10 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/rpi3.exs
+++ b/config/rpi3.exs
@@ -1,0 +1,10 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/rpi3a.exs
+++ b/config/rpi3a.exs
@@ -1,0 +1,10 @@
+use Mix.Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/rpi4.exs
+++ b/config/rpi4.exs
@@ -1,0 +1,11 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"usb0", %{type: VintageNetDirect}},
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}},
+    {"wlan0", %{type: VintageNetWiFi}}
+  ]

--- a/config/target.exs
+++ b/config/target.exs
@@ -37,20 +37,6 @@ config :nerves_ssh,
       'Password: ', false}}
   ]
 
-# Configure the network using vintage_net
-# See https://github.com/nerves-networking/vintage_net for more information
-config :vintage_net,
-  regulatory_domain: "US",
-  config: [
-    {"usb0", %{type: VintageNetDirect}},
-    {"eth0",
-     %{
-       type: VintageNetEthernet,
-       ipv4: %{method: :dhcp}
-     }},
-    {"wlan0", %{type: VintageNetWiFi}}
-  ]
-
 config :mdns_lite,
   # The `host` key specifies what hostnames mdns_lite advertises.  `:hostname`
   # advertises the device's hostname.local. For the official Nerves systems, this
@@ -85,6 +71,5 @@ config :mdns_lite,
 
 # Import target specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
-# Uncomment to use target specific configurations
 
-# import_config "#{Mix.target()}.exs"
+import_config "#{Mix.target()}.exs"

--- a/config/x86_64.exs
+++ b/config/x86_64.exs
@@ -1,0 +1,9 @@
+import Config
+
+# Configure the network using vintage_net
+# See https://github.com/nerves-networking/vintage_net for more information
+config :vintage_net,
+  regulatory_domain: "US",
+  config: [
+    {"eth0", %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  ]


### PR DESCRIPTION
Previously a generic setup was used that worked across all boards
with the caveat that it would configure some impossible-to-use
interfaces on some boards.

The NPI imx6ull board has an additional Ethernet interface. The two
options for supporting it are to add it to the generic config or to
split out the config per board. The latter option seems like it will
lead to the least confusion so go with it.
