### PR TITLE
Add support for provisioning WiFi

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Success!
 Elapsed time: 3.595 s
 ```
 
+If you're using a WiFi-enabled device and want the WiFi credentials to be
+written to the MicroSD card, initialize the MicroSD card like this instead:
+
+```sh
+export NERVES_WIFI_SSID='access_point'
+export NERVES_WIFI_PASSPHRASE='passphrase'
+fwup circuits_quickstart_rpi0.fw
+```
+
+You can still change the WiFi credentials at runtime using
+`VintageNetWiFi.quick_configure/2`, but this helps you don't have an easy
+alternative way of accessing the device to configure WiFi.
+
 It's quite fast. Now you have Nerves ready to run on your device.  Skip ahead to
 the next section.
 
@@ -97,6 +110,10 @@ Start [`etcher`](https://www.balena.io/etcher/), point it to the zip file, and
 follow the prompts:
 
 ![etcher screenshot](assets/etcher.png)
+
+IMPORTANT: There's no way to configure the initial WiFi credentials with
+`etcher`. If you have a device that you can only access via WiFi (so no way of
+setting credentials), then check out the `fwup` instructions above.
 
 ## GRiSP 2 installation
 
@@ -379,7 +396,7 @@ more information:
 * [SPI](https://hex.pm/packages/circuits_spi)
 * [UART](https://hex.pm/packages/circuits_uart)
 
-At some point you'll want to create your own firmware. See the [Nerves
+At some point you may want to create your own firmware. See the [Nerves
 Installation](https://hexdocs.pm/nerves/installation.html) and [Getting
 Started](https://hexdocs.pm/nerves/getting-started.html) guides for details.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,9 @@ config :circuits_quickstart, target: Mix.target()
 # Customize non-Elixir parts of the firmware. See
 # https://hexdocs.pm/nerves/advanced-configuration.html for details.
 
-config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
+config :nerves, :firmware,
+  rootfs_overlay: "rootfs_overlay",
+  provisioning: "config/provisioning.conf"
 
 # Set the SOURCE_DATE_EPOCH date for reproducible builds.
 # See https://reproducible-builds.org/docs/source-date-epoch/ for more information

--- a/config/provisioning.conf
+++ b/config/provisioning.conf
@@ -1,0 +1,20 @@
+# Support setting the initial WiFi credentials when creating MicroSD cards.
+#
+# Note that the '$' is escaped so that environment variable replacement happens
+# when firmware is written to the MicroSD card rather than when the '.fw' file
+# is created.  WiFi credentials are not stored in the .fw file. If left blank,
+# the device won't connect to WiFi and you'll need to configure it in this Mix
+# project or via an iex prompt.
+#
+# IMPORTANT: If you configure WiFi in this Mix project or via the IEx prompt,
+# that configuration will be persisted and these won't be used unless
+# $NERVES_WIFI_FORCE is set to "true" (or anything)
+uboot_setenv(uboot-env, "wifi_ssid", "\${NERVES_WIFI_SSID}")
+uboot_setenv(uboot-env, "wifi_passphrase", "\${NERVES_WIFI_PASSPHRASE}")
+uboot_setenv(uboot-env, "wifi_force", "\${NERVES_WIFI_FORCE}")
+
+# Normally the serial number comes from a unique device ID on the board.  Use
+# this to override the default serial number. The serial number is used to
+# determine the hostname so overriding the serial number can be convenient for
+# naming devices.
+uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")

--- a/lib/circuits_quickstart/application.ex
+++ b/lib/circuits_quickstart/application.ex
@@ -1,0 +1,54 @@
+defmodule CircuitsQuickstart.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    if target() != :host do
+      setup_wifi()
+    end
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: CircuitsQuickstart.Supervisor]
+
+    children = []
+
+    Supervisor.start_link(children, opts)
+  end
+
+  defp setup_wifi() do
+    kv = Nerves.Runtime.KV.get_all()
+
+    if true?(kv["wifi_force"]) or wlan0_unconfigured?() do
+      ssid = kv["wifi_ssid"]
+      passphrase = kv["wifi_passphrase"]
+
+      unless empty?(ssid) do
+        _ = VintageNetWiFi.quick_configure(ssid, passphrase)
+        :ok
+      end
+    end
+  end
+
+  defp wlan0_unconfigured?() do
+    "wlan0" in VintageNet.configured_interfaces() and
+      VintageNet.get_configuration("wlan0") == %{type: VintageNetWiFi}
+  end
+
+  defp true?(""), do: false
+  defp true?(nil), do: false
+  defp true?("false"), do: false
+  defp true?("FALSE"), do: false
+  defp true?(_), do: true
+
+  defp empty?(""), do: true
+  defp empty?(nil), do: true
+  defp empty?(_), do: false
+
+  defp target() do
+    Application.get_env(:circuits_quickstart, :target)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,7 @@ defmodule CircuitsQuickstart.MixProject do
 
   def application do
     [
+      mod: {CircuitsQuickstart.Application, []},
       extra_applications: [:logger, :runtime_tools, :inets, :ssl]
     ]
   end


### PR DESCRIPTION
This addresses Issue https://github.com/elixir-circuits/circuits_quickstart/issues/101
Adopted code from https://github.com/livebook-dev/nerves_livebook/pull/69

Testing locally

```
export MIX_TARGET='rpi0'
export NERVES_WIFI_SSID='access_point'
export NERVES_WIFI_PASSPHRASE='passphrase'

mix deps.get
mix firmware
fwup _build/rpi0_dev/nerves/images/circuits_quickstart.fw
```

✅ 
