### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Elixir Circuits quickstart firmware lets you try out the Elixir Circuits
 projects on real hardware without needing to create a Nerves project, install
 Elixir on Raspbian on a Raspberry Pi or compiling any Elixir code at all.
 Within minutes, you'll have a device running Nerves. You'll be able to explore
-the Nerves environment with [toolshed](https://hexdocs.pm/toolshed/readme.html),
+the Nerves environment with [toolshed](https://toolshed.hexdocs.pm/readme.html),
 and you'll be able to blink LEDs from the device itself. You'll also be able to
 explore the other Elixir Circuits libraries and experiment with
 [I2C](https://hex.pm/packages/circuits_i2c),
@@ -406,8 +406,8 @@ more information:
 * [UART](https://hex.pm/packages/circuits_uart)
 
 At some point you may want to create your own firmware. See the [Nerves
-Installation](https://hexdocs.pm/nerves/installation.html) and [Getting
-Started](https://hexdocs.pm/nerves/getting-started.html) guides for details.
+Installation](https://nerves.hexdocs.pm/installation.html) and [Getting
+Started](https://nerves.hexdocs.pm/getting-started.html) guides for details.
 
 To build the Elixir Circuits Quickstart firmware, make sure that you have run
 through the Nerves installation steps. Then open a terminal window and run the

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ import Config
 Application.start(:nerves_bootstrap)
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware,
   rootfs_overlay: "rootfs_overlay",

--- a/config/target.exs
+++ b/config/target.exs
@@ -15,15 +15,15 @@ config :nerves_runtime, startup_guard_enabled: true
 config :nerves, :erlinit, update_clock: true
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 config :nerves_ssh,
   daemon_option_overrides: [

--- a/lib/circuits_quickstart/application.ex
+++ b/lib/circuits_quickstart/application.ex
@@ -1,5 +1,5 @@
 defmodule CircuitsQuickstart.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 
@@ -11,7 +11,7 @@ defmodule CircuitsQuickstart.Application do
       setup_wifi()
     end
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
+    # See https://elixir.hexdocs.pm/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: CircuitsQuickstart.Supervisor]
 
@@ -21,7 +21,7 @@ defmodule CircuitsQuickstart.Application do
   end
 
   defp advertise_device() do
-    # See https://hexdocs.pm/nerves_discovery/
+    # See https://nerves-discovery.hexdocs.pm/
     MdnsLite.add_mdns_service(%{
       id: :nerves_device,
       protocol: "nerves-device",


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://toolshed.hexdocs.pm/readme.html): Status 404
❌ Verification failed for https://nerves.hexdocs.pm/installation.html): Status 301
❌ Verification failed for https://nerves.hexdocs.pm/getting-started.html): Status 301
⚠️ Verification finished: 7 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>